### PR TITLE
AEA-3740 Example for prescription with distance selling pharmacy contains wrong address format

### DIFF
--- a/specification/examples/GetMyPrescriptions/Bundle/success/success-distance-selling.json
+++ b/specification/examples/GetMyPrescriptions/Bundle/success/success-distance-selling.json
@@ -340,13 +340,8 @@
                 {
                   "use": "work",
                   "type": "both",
-                  "line": [
-                    "Unit 4B",
-                    "Victoria Road"
-                  ],
-                  "city": "Leeds",
-                  "district": "West Yorkshire",
-                  "postalCode": "LS1 2LA"
+                  "text": "Unit 4B, Victoria Road",
+                  "postalCode": "TR1 3FF"
                 }
               ]
             }


### PR DESCRIPTION
## Summary
Expected/Observed 

Expected behaviour

The example currently included in the PfP API catalogue for distance-selling-pharmacy  contains the following dispensing organisation address format:
"address": 
[{ "use": "work", "type": "both", "line": [ "Unit 4B", "Victoria Road"], "city": "Leeds", "district": "West Yorkshire", "postalCode": "LS1 2LA"}]

Observed behaviour:
The example included in the PfP API catalogue for distance-selling-pharmacy must contain the following dispensing organisation address format:
"address": [{ "use": "work", "type": "both", "text": "Unit 4B, Victoria Road", "postalCode": "TR1 3FF"}] 

Update the OAS file to modify the distance-selling-pharmacy response message example to include a dispensing organisation address, which reflects the expected format illustrated above.

* Routine Change
Changed the example of distance-selling-pharmacy documentation for address to the one mentioned on the ticket.

## Reviews Required
**Check who should review this. Remove this line once this has been done**
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the jira ticket has been updated with the github pull request link
