### PR TITLE
[AEA-3841] Fix Invalid Correlation ID returning 500

### DIFF
--- a/proxies/live/apiproxy/policies/AssignMessage.Errors.InvalidCorrelationID.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.Errors.InvalidCorrelationID.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<AssignMessage name="AssignMessage.Errors.InvalidRequestID">
+<AssignMessage name="AssignMessage.Errors.InvalidCorrelationID">
     <AssignVariable>
         <Name>pfp.error.code</Name>
         <Value>value</Value>

--- a/proxies/live/apiproxy/policies/AssignMessage.Errors.InvalidCorrelationID.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.Errors.InvalidCorrelationID.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<AssignMessage name="AssignMessage.Errors.InvalidRequestID">
+    <AssignVariable>
+        <Name>pfp.error.code</Name>
+        <Value>value</Value>
+    </AssignVariable>
+    <AssignVariable>
+        <Name>pfp.error.coding.code</Name>
+        <Value>INVALID_VALUE</Value>
+    </AssignVariable>
+    <AssignVariable>
+        <Name>pfp.error.coding.display</Name>
+        <Value>Provided value is invalid</Value>
+    </AssignVariable>
+    <AssignVariable>
+        <Name>pfp.error.diagnostics</Name>
+        <Template>Invalid value - '{original-request-details.header.X-Correlation-ID}' in header 'X-Correlation-ID'</Template>
+    </AssignVariable>
+    <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</AssignMessage>

--- a/proxies/live/apiproxy/policies/AssignMessage.Errors.InvalidCorrelationID.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.Errors.InvalidCorrelationID.xml
@@ -10,7 +10,7 @@
     </AssignVariable>
     <AssignVariable>
         <Name>pfp.error.coding.display</Name>
-        <Value>Provided value is invalid</Value>
+        <Value>Invalid value</Value>
     </AssignVariable>
     <AssignVariable>
         <Name>pfp.error.diagnostics</Name>

--- a/proxies/live/apiproxy/policies/RaiseFault.400InvalidCorrelationID.xml
+++ b/proxies/live/apiproxy/policies/RaiseFault.400InvalidCorrelationID.xml
@@ -1,0 +1,30 @@
+<RaiseFault async="false" continueOnError="false" enabled="true" name="RaiseFault.400InvalidCorrelationID">
+    <FaultResponse>
+        <Set>
+          <Payload contentType="application/fhir+json">
+            {
+              "resourceType": "OperationOutcome",
+              "issue": [
+                {
+                  "severity": "fatal",
+                  "code": "value",
+                  "details": {
+                    "coding": [
+                      {
+                        "system": "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
+                        "version": "1",
+                        "code": "INVALID_VALUE",
+                        "display": "Invalid X-Correlation-ID"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          </Payload>
+          <StatusCode>400</StatusCode>
+          <ReasonPhrase>Bad Request</ReasonPhrase>
+        </Set>
+    </FaultResponse>
+    <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/proxies/live/apiproxy/targets/target.xml
+++ b/proxies/live/apiproxy/targets/target.xml
@@ -57,7 +57,7 @@
       </Step>
     </FaultRule>
     <FaultRule name="invalid_correlation_id">
-      <Condition>(original-request-details.header.X-Correlation-ID != null) and (not original-request-details.header.X-Correlation-ID ~~ "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")</Condition>
+      <Condition>not original-request-details.header.X-Correlation-ID ~~ "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"</Condition>
       <Step>
         <Name>AssignMessage.Errors.InvalidCorrelationID</Name>
       </Step>

--- a/proxies/live/apiproxy/targets/target.xml
+++ b/proxies/live/apiproxy/targets/target.xml
@@ -27,6 +27,11 @@
           <Condition>(not original-request-details.header.X-Request-ID ~~ "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")</Condition>
         </Step>
         <Step>
+          <!-- Header X-Correlation-ID must be in the correct format (GUID) -->
+          <Name>RaiseFault.400InvalidCorrelationID</Name>
+          <Condition>(not original-request-details.header.X-Correlation-ID ~~ "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")</Condition>
+        </Step>
+        <Step>
           <Name>FlowCallout.ApplyRateLimiting</Name>
         </Step>
       </Request>
@@ -46,6 +51,15 @@
       <Condition>(original-request-details.header.X-Request-ID != null) and (not original-request-details.header.X-Request-ID ~~ "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")</Condition>
       <Step>
         <Name>AssignMessage.Errors.InvalidRequestID</Name>
+      </Step>
+      <Step>
+        <Name>AssignMessage.Errors.CatchAllMessage</Name>
+      </Step>
+    </FaultRule>
+    <FaultRule name="invalid_correlation_id">
+      <Condition>(original-request-details.header.X-Correlation-ID != null) and (not original-request-details.header.X-Correlation-ID ~~ "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")</Condition>
+      <Step>
+        <Name>AssignMessage.Errors.InvalidCorrelationID</Name>
       </Step>
       <Step>
         <Name>AssignMessage.Errors.CatchAllMessage</Name>

--- a/proxies/live/apiproxy/targets/target.xml
+++ b/proxies/live/apiproxy/targets/target.xml
@@ -29,7 +29,7 @@
         <Step>
           <!-- Header X-Correlation-ID must be in the correct format (GUID) -->
           <Name>RaiseFault.400InvalidCorrelationID</Name>
-          <Condition>(not original-request-details.header.X-Correlation-ID ~~ "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")</Condition>
+          <Condition>(original-request-details.header.X-Correlation-ID != null) and (not original-request-details.header.X-Correlation-ID ~~ "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")</Condition>
         </Step>
         <Step>
           <Name>FlowCallout.ApplyRateLimiting</Name>
@@ -57,7 +57,7 @@
       </Step>
     </FaultRule>
     <FaultRule name="invalid_correlation_id">
-      <Condition>(original-request-details.header.X-Correlation-ID != null and not original-request-details.header.X-Correlation-ID ~~ "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")</Condition>
+      <Condition>(original-request-details.header.X-Correlation-ID != null) and (not original-request-details.header.X-Correlation-ID ~~ "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")</Condition>
       <Step>
         <Name>AssignMessage.Errors.InvalidCorrelationID</Name>
       </Step>

--- a/proxies/live/apiproxy/targets/target.xml
+++ b/proxies/live/apiproxy/targets/target.xml
@@ -57,7 +57,7 @@
       </Step>
     </FaultRule>
     <FaultRule name="invalid_correlation_id">
-      <Condition>not original-request-details.header.X-Correlation-ID ~~ "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"</Condition>
+      <Condition>(original-request-details.header.X-Correlation-ID != null and not original-request-details.header.X-Correlation-ID ~~ "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")</Condition>
       <Step>
         <Name>AssignMessage.Errors.InvalidCorrelationID</Name>
       </Step>

--- a/specification/prescriptions-for-patients.yaml
+++ b/specification/prescriptions-for-patients.yaml
@@ -220,10 +220,11 @@ components:
       name: X-Correlation-ID
       required: false
       description: |
-        An optional ID which you can use to track transactions across multiple systems. It can have any value, but we recommend avoiding `.` characters.
+        An optional ID which you can use to track transactions across multiple systems. If included its value must be a valid GUID.
         Mirrored back in a response header.
       schema:
         type: string
+        pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
         example: 11C46F5F-CDEF-4865-94B2-0EE0EDCC26DA
   schemas:
     bundle-response:

--- a/specification/prescriptions-for-patients.yaml
+++ b/specification/prescriptions-for-patients.yaml
@@ -220,7 +220,7 @@ components:
       name: X-Correlation-ID
       required: false
       description: |
-        An optional ID which you can use to track transactions across multiple systems. If included its value must be a valid GUID.
+        An optional ID which you can use to track transactions across multiple systems. If included, its value must be a valid GUID.
         Mirrored back in a response header.
       schema:
         type: string


### PR DESCRIPTION
## Summary
- :exclamation: Breaking Change
- :warning: Potential issues that might be caused by this change

### Details
Updates proxy config so that if a X-Correlation-ID header is included it must now be a valid GUID or else it will return a 400 response. The header is still optional but this stricter validation on its value now invalidates previous documentation that the header could contain any value so may impact users of the API.
