### PR TITLE
AEA-3840 Fix content-type header when X-Request-ID is invalid

### DIFF
--- a/proxies/live/apiproxy/policies/AssignMessage.Errors.CatchAllMessage.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.Errors.CatchAllMessage.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <AssignMessage async="false" continueOnError="false" enabled="true" name="AssignMessage.Errors.CatchAllMessage">
   <Set>
-    <Payload contentType="application/json">
+    <Payload contentType="application/fhir+json">
       {
         "resourceType": "OperationOutcome",
         "issue": [

--- a/proxies/live/apiproxy/policies/AssignMessage.OAuthPolicyErrorResponse.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.OAuthPolicyErrorResponse.xml
@@ -1,7 +1,7 @@
 <AssignMessage async="false" continueOnError="false" enabled="true" name="AssignMessage.OAuthPolicyErrorResponse">
   <Set>
     <StatusCode>401</StatusCode>
-    <Payload contentType="application/json">
+    <Payload contentType="application/fhir+json">
       {
         "resourceType": "OperationOutcome",
         "issue": [

--- a/proxies/sandbox/apiproxy/policies/AssignMessage.Errors.CatchAllMessage.xml
+++ b/proxies/sandbox/apiproxy/policies/AssignMessage.Errors.CatchAllMessage.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <AssignMessage async="false" continueOnError="false" enabled="true" name="AssignMessage.Errors.CatchAllMessage">
   <Set>
-    <Payload contentType="application/json" variablePrefix="%" variableSuffix="#">
+    <Payload contentType="application/fhir+json" variablePrefix="%" variableSuffix="#">
     {
         "resourceType": "OperationOutcome",
         "issue": [

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -1,0 +1,35 @@
+"""
+See
+https://github.com/NHSDigital/pytest-nhsd-apim/blob/main/tests/test_examples.py
+for more ideas on how to test the authorization of your API.
+"""
+import pytest
+import requests
+import uuid
+
+
+@pytest.mark.nhsd_apim_authorization(
+    {
+        "access": "patient",
+        "level": "P9",
+        "login_form": {"username": "9912003071"},
+        "authentication": "separate",
+    }
+)
+@pytest.mark.parametrize(
+        "x_request_id",
+        [
+            pytest.param("invalid"),
+            pytest.param("")
+        ]
+    )
+def test_expected_content_type_headers_when_x_request_id_invalid(
+    x_request_id, nhsd_apim_proxy_url, nhsd_apim_auth_headers
+):
+    request_headers = nhsd_apim_auth_headers
+    request_headers["X-Request-Id"] = x_request_id
+    request_headers["X-Correlation-ID"] = str(uuid.uuid4())
+    resp = requests.get(f"{nhsd_apim_proxy_url}/Bundle", headers=request_headers)
+
+    assert resp.status_code == 400
+    assert resp.headers["Content-Type"] == "application/fhir+json"


### PR DESCRIPTION
## Summary

- Routine Change: Content-Type header updated in all policies in which 'fhir' was missing. Integration tests included for invalid x-request-id.