### PR TITLE
[AEA-3862] Reduce PfP API time out to a period of time less than the NHS App timeout

### DIFF
--- a/proxies/live/apiproxy/targets/target.xml
+++ b/proxies/live/apiproxy/targets/target.xml
@@ -78,9 +78,10 @@
     <SSLInfo>
       <Enabled>true</Enabled>
     </SSLInfo>
-    <LoadBalancer>
+    <!-- <LoadBalancer>
       <Server name="prescriptions-for-patients" />
-    </LoadBalancer>
+    </LoadBalancer> -->
+    <URL>https://httpbin.org/delay/10</URL>
     <Properties>
       <Property name="io.timeout.millis">10000</Property>
     </Properties>

--- a/proxies/live/apiproxy/targets/target.xml
+++ b/proxies/live/apiproxy/targets/target.xml
@@ -81,5 +81,8 @@
     <LoadBalancer>
       <Server name="prescriptions-for-patients" />
     </LoadBalancer>
+    <Properties>
+      <Property name="io.timeout.millis">10000</Property>
+    </Properties>
   </HTTPTargetConnection>
 </TargetEndpoint>

--- a/proxies/sandbox/apiproxy/targets/sandbox.xml
+++ b/proxies/sandbox/apiproxy/targets/sandbox.xml
@@ -21,5 +21,8 @@
       <LoadBalancer>
         <Server name="prescriptions-for-patients" />
       </LoadBalancer>
+      <Properties>
+        <Property name="io.timeout.millis">10000</Property>
+      </Properties>
     </HTTPTargetConnection>
 </TargetEndpoint>


### PR DESCRIPTION
## Summary

- Routine Change

### Details

Adds a 10s timeout to live and sandbox proxies.
