### PR TITLE
Fix: [AEA-4251] - Switch to new PfP API processing stack [PROD ONLY]

### DIFF
--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -101,4 +101,4 @@ extends:
           - int
         jinja_templates:
           ALLOW_NHS_NUMBER_OVERRIDE: false
-          TARGET_SERVER: prescriptions-for-patients
+          TARGET_SERVER: prescriptions-for-patients-eps


### PR DESCRIPTION
## Summary

🎫 [AEA-4251](https://nhsd-jira.digital.nhs.uk/browse/AEA-4251) Switch to new PfP API processing stack [PROD ONLY]

- Routine Change

### Details

Acceptance Criteria 
- The solution must provide a mechanism to switch over to the new PfP API processing stack in PROD environment
- When making a call to pfp apigee with target server set to prescriptions-for-patients-eps, the request should go to step function rather than direct to lambda